### PR TITLE
Release 0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="treescript-builder",
-    version="0.1.2",
+    version="0.2",
     description='Builds File Trees from TreeScript. If DataLabels are present in TreeScript, a DataDirectory argument is required.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/treescript_builder/input/test_argument_parser.py
+++ b/test/treescript_builder/input/test_argument_parser.py
@@ -6,10 +6,19 @@ from treescript_builder.input import parse_arguments
 from treescript_builder.input.argument_data import ArgumentData
 
 
+def test_parse_arguments_empty_list_raises_exit():
+    with pytest.raises(SystemExit, match='The TreeScript file path argument is required.'):
+        parse_arguments([])
+        
+
+def test_parse_arguments_none_raises_exit():
+    with pytest.raises(SystemExit, match='The TreeScript file path argument is required.'):
+        parse_arguments(None)
+
+
 @pytest.mark.parametrize(
     "test_input",
     [
-        ([]),
         ([""]),
         ([" "]),
         (["--data"]),
@@ -17,24 +26,49 @@ from treescript_builder.input.argument_data import ArgumentData
         (["tree_file", "--data_dir="]),
     ]
 )
-def test_parse_arguments_raises_value_error(test_input):
-    with pytest.raises(SystemExit) as exit_info:
+def test_parse_arguments_raises_system_exit(test_input):
+    with pytest.raises(SystemExit):
         parse_arguments(test_input)
-    assert exit_info.type == SystemExit
 
 
 @pytest.mark.parametrize(
     "test_input,expect",
     [
-        (["tree_file"], ArgumentData("tree_file", None, False)),
-        (["tree_file"], ArgumentData("tree_file", None, False)),
-        (["tree_file", "--data_dir=data"], ArgumentData("tree_file", "data", False)),
-        (["tree_file", "--data_dir=data", "-r"], ArgumentData("tree_file", "data", True)),
-        (["tree_file", "--data_dir=data", "-r"], ArgumentData("tree_file", "data", True)),
-        (["tree_file", "-r"], ArgumentData("tree_file", None, True)),
-        (["tree_file", "--reverse"], ArgumentData("tree_file", None, True)),
-        (["tree_file", "--trim"], ArgumentData("tree_file", None, True)),
+        # No DataDir, Just Shorthand Options
+        (["tree_file"], ArgumentData("tree_file", None, False, False, False)),
+        (["tree_file", "-p"], ArgumentData("tree_file", None, False, False, True)),
+        (["tree_file", "-o"], ArgumentData("tree_file", None, False, True, False)),
+        (["tree_file", "-r"], ArgumentData("tree_file", None, True, False, False)),
+        (["tree_file", "-pr"], ArgumentData("tree_file", None, True, False, True)),
+        (["tree_file", "-or"], ArgumentData("tree_file", None, True, True, False)),
+        # Data Dir, And Shorthand Options
+        (["tree_file", "--data_dir=data"], ArgumentData("tree_file", "data", False, False, False)),
+        (["tree_file", "--data_dir=data", "-p"], ArgumentData("tree_file", "data", False, False, True)),
+        (["tree_file", "--data_dir=data", "-o"], ArgumentData("tree_file", "data", False, True, False)),
+        (["tree_file", "--data_dir=data", "-r"], ArgumentData("tree_file", "data", True, False, False)),
+        (["tree_file", "--data_dir=data", "-ro"], ArgumentData("tree_file", "data", True, True, False)),
+        (["tree_file", "--data_dir", "data", "-rp"], ArgumentData("tree_file", "data", True, False, True)),
+        # Full Arg Names
+        (["tree_file", "--reverse"], ArgumentData("tree_file", None, True, False, False)),
+        (["tree_file", "--trim"], ArgumentData("tree_file", None, True, False, False)),
+        (["tree_file", "--overwrite"], ArgumentData("tree_file", None, False, True, False)),
+        (["tree_file", "--prepend"], ArgumentData("tree_file", None, False, False, True)),
+        (["tree_file", "--overwrite", '--reverse'], ArgumentData("tree_file", None, True, True, False)),
+        (["tree_file", "--prepend", '--reverse'], ArgumentData("tree_file", None, True, False, True)),
     ]
 )
 def test_parse_arguments_returns_data(test_input, expect):
     assert parse_arguments(test_input) == expect
+
+
+@pytest.mark.parametrize(
+    "test_input", [
+        (["tree_file", "-po"]),
+        (["tree_file", "-rpo"]),
+        (["tree_file", '--reverse', "-po"]),
+        (["tree_file", '--reverse', "-po", "--data_dir", "data"]),
+    ]
+)
+def test_parse_arguments_invalid_option_combinations_raise_system_exit(test_input):
+    with pytest.raises(SystemExit, match='Invalid Option Combination.'):
+        parse_arguments(test_input)

--- a/treescript_builder/input/__init__.py
+++ b/treescript_builder/input/__init__.py
@@ -22,7 +22,9 @@ def validate_input_arguments(arguments: list[str]) -> InputData:
     """
     arg_data = parse_arguments(arguments)
     return InputData(
-        validate_input_file(arg_data.input_file_path_str),
-        validate_directory(arg_data.data_dir_path_str),
-        arg_data.is_reversed
+        tree_input=validate_input_file(arg_data.input_file_path_str),
+        data_dir=validate_directory(arg_data.data_dir_path_str),
+        is_reversed=arg_data.is_reversed,
+        append=not arg_data.overwrite and not arg_data.prepend,
+        prepend=arg_data.prepend,
     )

--- a/treescript_builder/input/argument_data.py
+++ b/treescript_builder/input/argument_data.py
@@ -11,12 +11,17 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class ArgumentData:
     """ The syntactically valid arguments received by the Program.
+- The Default Mode Appends data to the end of existing files.
 
 **Fields:**
  - input_file_path_str (str): The Name of the File containing the Tree Structure.
- - data_dir_path_str (str?): The Directory Name containing Files Used in File Tree Operation.
- - is_reversed (bool): Flag to determine if the File Tree Operation Is To be Oppositely Trimmed.
+ - data_dir_path_str (str?): The Directory Name containing Files Used in File Tree Operation. Default: False.
+ - is_reversed (bool): Flag to determine if the File Tree Operation Is Trim. Default: False.
+ - overwrite (bool): Optional Mode of overwriting data in existing files. Default: False.
+ - prepend (bool): Optional Mode of prepending data at the start of existing files. Default: False.
     """
     input_file_path_str: str
-    data_dir_path_str: str | None
-    is_reversed: bool
+    data_dir_path_str: str | None = None
+    is_reversed: bool = False
+    overwrite: bool = False
+    prepend: bool = False

--- a/treescript_builder/input/argument_parser.py
+++ b/treescript_builder/input/argument_parser.py
@@ -22,7 +22,7 @@ def parse_arguments(
  ArgumentData - Container for Valid Argument Data.
     """
     if args is None or len(args) == 0:
-        exit("No Arguments given.")
+        exit("The TreeScript file path argument is required.")
     try: # Initialize the Parser and Parse Immediately
         parsed_args = _define_arguments().parse_args(args)
     except SystemExit as e:
@@ -30,14 +30,18 @@ def parse_arguments(
     return _validate_arguments(
         parsed_args.tree_file_name,
         parsed_args.data_dir,
-        parsed_args.reverse
+        parsed_args.reverse,
+        parsed_args.overwrite,
+        parsed_args.prepend,
     )
 
 
 def _validate_arguments(
     tree_file_name: str,
     data_dir_name: str,
-    is_reverse: bool
+    is_reverse: bool,
+    overwrite: bool,
+    prepend: bool,
 ) -> ArgumentData:
     """ Checks the values received from the ArgParser.
  - Uses Validate Name method from StringValidation.
@@ -47,22 +51,27 @@ def _validate_arguments(
  - tree_file_name (str): The file name of the tree input.
  - data_dir_name (str): The Data Directory name.
  - is_reverse (bool): Whether the builder operation is reversed.
+ - overwrite (bool): Option to Overwrite the data in existing files.
+ - prepend (bool): Option to Prepend the data, to the start of each file.
 
 **Returns:**
  ArgumentData - A DataClass of syntactically correct arguments.
     """
     # Validate Tree Name Syntax
-    if not validate_name(tree_file_name):
+    if tree_file_name is None or not validate_name(tree_file_name):
         exit("The Tree File argument was invalid.")
     # Validate Data Directory Name Syntax if Present
-    if data_dir_name is None:
-        pass
-    elif not validate_name(data_dir_name):
+    if data_dir_name is not None and not validate_name(data_dir_name):
         exit("The Data Directory argument was invalid.")
+    # Validate The Option Combination
+    if overwrite and prepend:
+        exit("Invalid Option Combination.")
     return ArgumentData(
-        tree_file_name,
-        data_dir_name,
-        is_reverse
+        input_file_path_str=tree_file_name,
+        data_dir_path_str=data_dir_name,
+        is_reversed=is_reverse,
+        overwrite=overwrite,
+        prepend=prepend,
     )
 
 
@@ -95,5 +104,19 @@ def _define_arguments() -> ArgumentParser:
         action='store_true',
         default=False,
         help='Flag to reverse the File Tree Operation'
+    )
+    parser.add_argument(
+        '-o',
+        '--overwrite',
+        action='store_true',
+        default=False,
+        help='Flag to overwrite files with data.'
+    )
+    parser.add_argument(
+        '-p',
+        '--prepend',
+        action='store_true',
+        default=False,
+        help='Flag to insert data at the start of files.'
     )
     return parser

--- a/treescript_builder/input/input_data.py
+++ b/treescript_builder/input/input_data.py
@@ -11,9 +11,13 @@ class InputData:
 
 **Fields:**
  - tree_input (str): The Tree Input to the FTB operation.
- - data_dir (Path?): An Optional Path to the Data Directory.
- - is_reversed (bool): Whether this FTB operation is reversed.
+ - data_dir (Path?): An Optional Path to the Data Directory. Default: None
+ - is_reversed (bool): Whether this FTB operation is reversed. Default: False
+ - append (bool): Whether to append data to the end of files. Default: True
+ - prepend (bool): Whether to insert data at the start of files. Default: False.
     """
     tree_input: str
-    data_dir: Path | None
-    is_reversed: bool
+    data_dir: Path | None = None
+    is_reversed: bool = False
+    append: bool = True
+    prepend: bool = False


### PR DESCRIPTION
## Important New Feature Changes
- Data is now appended to the end of files by default.
- To continue using the previous default, add the `--overwrite` argument or it's shorthand `-c`.

### New CLI Arguments
- `-o` or `--overwrite`
- `-p` or `--prepend`

### Data Changes
Note that existing files are now appended to by default.
  - This will affect workflows that rely on overwriting files.
  - Mitigate this by adding `-o` to your affected workflow TreeScript commands.
