### PR TITLE
Release 0.1.5

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [ '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.11', '3.12', '3.13', '3.14.0-rc.3' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [ '3.12', '3.13' ]
+        python-version: [ '3.11', '3.12', '3.13', '3.14' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,6 @@ jobs:
           cd ../
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           print-hash: true

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="treescript-builder",
-    version="0.1.4",
+    version="0.1.5",
     description='Builds File Trees from TreeScript. If DataLabels are present in TreeScript, a DataDirectory argument is required.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
@@ -23,7 +23,7 @@ setup(
             'treescript-builder=treescript_builder.__main__:main',
         ],
     },
-    python_requires='>=3.12',
+    python_requires='>=3.11',
     keywords=['TreeScript', 'Files', 'Directory'],
     classifiers=[
         'Natural Language :: English',
@@ -31,6 +31,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
     ],


### PR DESCRIPTION
## Python Version Support
- Reduce Min Version from 3.12 to 3.11

## GitHub Workflows 
- [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) [1.13.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.13.0)
- Add Python 3.14 to tests